### PR TITLE
Fix: deprecated abstract class from `collections`

### DIFF
--- a/reckit/util/decorators.py
+++ b/reckit/util/decorators.py
@@ -6,7 +6,7 @@ __all__ = ["typeassert", "timer"]
 import time
 from inspect import signature
 from functools import wraps
-from collections import Iterable
+from typing import Iterable
 
 
 def typeassert(*type_args, **type_kwargs):


### PR DESCRIPTION
In Python 3.10, `Iterable` has been removed from the `collections` namespace.

> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3.10/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/3.10/library/collections.html#module-collections) module. (Contributed by Victor Stinner in [bpo-37324](https://bugs.python.org/issue?@action=redirect&bpo=37324).)
> Reference: [What's new in Python 3.10?](https://docs.python.org/3.10/whatsnew/3.10.html)
